### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,6 +1,8 @@
 name: Python package
 
 on: [push]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/sjhawke/piface-cad/security/code-scanning/1](https://github.com/sjhawke/piface-cad/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only requires read access to repository contents, we will set `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit the least privilege required to complete their tasks. No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
